### PR TITLE
fix(client): mic leak on pre-join, light default theme, viewport heig…

### DIFF
--- a/app/[meetCode]/layout.tsx
+++ b/app/[meetCode]/layout.tsx
@@ -7,8 +7,14 @@ import {useJoinMeetStore} from "@/src/stores/joinMeet";
 export default function MeetLayout({children,}: { children: React.ReactNode; }) {
     const {hasJoinedMeet} = useJoinMeetStore()
 
-    return <>
-        {!hasJoinedMeet && <Navbar/>}
-        {children}
-    </>
+    if (hasJoinedMeet) {
+        return <>{children}</>;
+    }
+
+    return (
+        <div className="flex min-h-screen flex-col">
+            <Navbar/>
+            <div className="flex flex-1 flex-col">{children}</div>
+        </div>
+    );
 }

--- a/app/[meetCode]/page.tsx
+++ b/app/[meetCode]/page.tsx
@@ -43,7 +43,7 @@ export default function MeetManager() {
     }, [clearAll, clearMeet, setHasJoinedMeet, setMeetCode]);
 
     return (
-        <div>
+        <div className="flex flex-1 flex-col">
             {hasJoinedMeet ? <MeetCall client={client} /> : <JoinMeet />}
         </div>
     );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const themeScript = `
 (() => {
   const key = "vartalaap-theme";
   const saved = localStorage.getItem(key);
-  const theme = saved === "light" || saved === "dark" || saved === "system" ? saved : "system";
+  const theme = saved === "light" || saved === "dark" || saved === "system" ? saved : "light";
   const dark = theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
   document.documentElement.classList.toggle("dark", dark);
   document.documentElement.dataset.theme = dark ? "dark" : "light";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,10 +28,10 @@ export default function Home() {
     };
 
     return (
-        <div className="min-h-screen">
+        <div className="flex min-h-screen flex-col">
             <Navbar />
-            <main className='mx-auto flex max-w-5xl flex-col px-4 py-10 sm:px-6 lg:px-8 lg:py-16'>
-                <section className='flex min-h-[calc(100vh-10rem)] items-center justify-center'>
+            <main className='mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8 lg:py-16'>
+                <section className='flex flex-1 items-center justify-center'>
                     <div className='w-full max-w-3xl text-center'>
                         <p className='text-sm font-medium uppercase tracking-[0.24em] text-[hsl(var(--muted-foreground))]'>
                             Vartalaap

--- a/src/components/features/JoinMeet.tsx
+++ b/src/components/features/JoinMeet.tsx
@@ -41,6 +41,7 @@ export default function JoinMeet() {
                 toast.error("Camera unavailable. Check browser permissions and try again.");
                 return;
             }
+            stream.getAudioTracks().forEach((t) => { t.enabled = !isMuted });
             if (videoRef.current) {
                 videoRef.current.srcObject = stream;
             }
@@ -61,7 +62,11 @@ export default function JoinMeet() {
     const handleJoinMeet = async () => {
         if (!userName.trim()) return;
         if (!localStream && !isVideoOff) {
-            await initializeCamera();
+            const stream = await initializeCamera();
+            if (stream) {
+                stream.getAudioTracks().forEach((t) => { t.enabled = !isMuted });
+                stream.getVideoTracks().forEach((t) => { t.enabled = !isVideoOff });
+            }
         }
         setHasJoinedMeet(true);
     };
@@ -81,11 +86,11 @@ export default function JoinMeet() {
     const initials = initialsOf(previewName);
 
     return (
-        <main className='relative min-h-screen overflow-hidden text-[hsl(var(--foreground))]'>
+        <main className='relative flex flex-1 overflow-hidden text-[hsl(var(--foreground))]'>
             <div className='pointer-events-none absolute inset-0 opacity-[0.08]'
                  style={{ background: 'radial-gradient(50% 40% at 50% 0%, hsl(var(--brand-glow) / 0.42) 0%, transparent 70%)' }} />
 
-            <div className='relative max-w-6xl mx-auto px-4 py-8 lg:py-14 min-h-screen flex items-center'>
+            <div className='relative w-full max-w-6xl mx-auto px-4 py-8 lg:py-14 flex items-center'>
                 <div className='grid grid-cols-1 lg:grid-cols-5 gap-8 w-full'>
                     {/* Preview tile */}
                     <div className='lg:col-span-3 flex flex-col items-center justify-center'>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -32,14 +32,14 @@ function applyTheme(theme: ThemeMode) {
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-    const [theme, setThemeState] = useState<ThemeMode>("system");
+    const [theme, setThemeState] = useState<ThemeMode>("light");
     const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
 
     useEffect(() => {
         const savedTheme = window.localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
         const initialTheme = savedTheme === "light" || savedTheme === "dark" || savedTheme === "system"
             ? savedTheme
-            : "system";
+            : "light";
 
         setThemeState(initialTheme);
 


### PR DESCRIPTION
…ht overflow

- JoinMeet: apply isMuted/isVideoOff to track.enabled after initializeCamera so a stream created with default-enabled audio tracks is not transmitted to peers when the user joined with mic off.
- Default theme switched from "system" to "light" in both the inline head script and ThemeProvider so first paint matches the documented default.
- Home and JoinMeet pages used nested min-h-screen under a sticky Navbar, producing ~Navbar-height of extra scrollable space. Replace with flex column + flex-1 fills so content fits the viewport exactly.