### PR TITLE
fix(client): keep [meetCode] layout wrapper stable across join toggle

### DIFF
--- a/app/[meetCode]/layout.tsx
+++ b/app/[meetCode]/layout.tsx
@@ -7,13 +7,9 @@ import {useJoinMeetStore} from "@/src/stores/joinMeet";
 export default function MeetLayout({children,}: { children: React.ReactNode; }) {
     const {hasJoinedMeet} = useJoinMeetStore()
 
-    if (hasJoinedMeet) {
-        return <>{children}</>;
-    }
-
     return (
         <div className="flex min-h-screen flex-col">
-            <Navbar/>
+            {!hasJoinedMeet && <Navbar/>}
             <div className="flex flex-1 flex-col">{children}</div>
         </div>
     );


### PR DESCRIPTION
The previous change returned a different wrapper element depending on hasJoinedMeet. Flipping the flag from JoinMeet remounted the page, whose cleanup effect resets hasJoinedMeet back to false, so Join now did nothing. Render the same flex-col wrapper in both states and only toggle the Navbar.