### PR TITLE
fix: add error boundaries around MeetCall

### DIFF
--- a/app/[meetCode]/error.tsx
+++ b/app/[meetCode]/error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { PhoneOff, RefreshCw } from "lucide-react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function MeetError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    const router = useRouter();
+
+    useEffect(() => {
+        Sentry.captureException(error);
+    }, [error]);
+
+    return (
+        <div className="flex min-h-dvh flex-col items-center justify-center gap-6 px-6 text-center">
+            <p className="text-sm font-medium">Something went wrong in the call</p>
+            {error.digest && (
+                <p className="text-xs text-[hsl(var(--muted-foreground))]">
+                    Reference: {error.digest}
+                </p>
+            )}
+            <div className="flex gap-3">
+                <button
+                    type="button"
+                    onClick={reset}
+                    className="ctrl-btn ctrl-btn-on flex items-center gap-2 px-4 py-2 text-sm"
+                >
+                    <RefreshCw className="h-4 w-4" />
+                    Try again
+                </button>
+                <button
+                    type="button"
+                    onClick={() => router.push("/")}
+                    className="ctrl-btn ctrl-btn-off flex items-center gap-2 px-4 py-2 text-sm"
+                >
+                    <PhoneOff className="h-4 w-4" />
+                    Leave call
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/app/[meetCode]/page.tsx
+++ b/app/[meetCode]/page.tsx
@@ -2,6 +2,7 @@
 
 import JoinMeet from "@/src/components/features/JoinMeet";
 import MeetCall from "@/src/components/features/MeetCall";
+import { CallErrorBoundary } from "@/src/components/ui/CallErrorBoundary";
 import { useJoinMeetStore } from "@/src/stores/joinMeet";
 import { useMeetStore } from "@/src/stores/meet";
 import { useParams } from "next/navigation";
@@ -43,10 +44,21 @@ export default function MeetManager() {
         };
     }, [clearAll, clearMeet, setHasJoinedMeet, setMeetCode]);
 
+    const handleLeave = () => {
+        clearAll();
+        clearMeet();
+        setHasJoinedMeet(false);
+        setMeetCode("");
+    };
+
     return (
         <div className="flex flex-1 flex-col">
             {hasJoinedMeet
-                ? <MeetCall client={client} connState={connState} reconnectAttempt={reconnectAttempt} routeMeetCode={meetCode} />
+                ? (
+                    <CallErrorBoundary onLeave={handleLeave}>
+                        <MeetCall client={client} connState={connState} reconnectAttempt={reconnectAttempt} routeMeetCode={meetCode} />
+                    </CallErrorBoundary>
+                )
                 : <JoinMeet />}
         </div>
     );

--- a/src/components/ui/CallErrorBoundary.tsx
+++ b/src/components/ui/CallErrorBoundary.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import * as Sentry from "@sentry/nextjs";
+import { PhoneOff, RefreshCw } from "lucide-react";
+
+interface Props {
+    children: React.ReactNode;
+    onLeave?: () => void;
+}
+
+interface State {
+    hasError: boolean;
+    eventId: string | null;
+}
+
+export class CallErrorBoundary extends React.Component<Props, State> {
+    state: State = { hasError: false, eventId: null };
+
+    static getDerivedStateFromError(): Partial<State> {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
+        const eventId = Sentry.captureException(error, {
+            extra: { componentStack: info.componentStack },
+        });
+        this.setState({ eventId: eventId ?? null });
+    }
+
+    private handleReset = () => {
+        this.setState({ hasError: false, eventId: null });
+    };
+
+    render() {
+        if (!this.state.hasError) return this.props.children;
+
+        return (
+            <div className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-[hsl(var(--background))] px-6 text-center">
+                <p className="text-sm font-medium text-[hsl(var(--foreground))]">
+                    Something went wrong in the call
+                </p>
+                {this.state.eventId && (
+                    <p className="text-xs text-[hsl(var(--muted-foreground))]">
+                        Reference: {this.state.eventId}
+                    </p>
+                )}
+                <div className="flex gap-3">
+                    <button
+                        type="button"
+                        onClick={this.handleReset}
+                        className="ctrl-btn ctrl-btn-on flex items-center gap-2 px-4 py-2 text-sm"
+                    >
+                        <RefreshCw className="h-4 w-4" />
+                        Try again
+                    </button>
+                    {this.props.onLeave && (
+                        <button
+                            type="button"
+                            onClick={this.props.onLeave}
+                            className="ctrl-btn ctrl-btn-off flex items-center gap-2 px-4 py-2 text-sm"
+                        >
+                            <PhoneOff className="h-4 w-4" />
+                            Leave call
+                        </button>
+                    )}
+                </div>
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
Add CallErrorBoundary class component that catches render errors in the call UI, reports to Sentry with an event ID, and offers Try again / Leave call recovery. Wrap MeetCall in MeetManager with it. Add app/[meetCode]/error.tsx as a Next.js route-level safety net for anything not caught by the component boundary.