### PR TITLE
fix: pre-fetch ICE servers on join screen instead of after join

### DIFF
--- a/src/components/features/JoinMeet.tsx
+++ b/src/components/features/JoinMeet.tsx
@@ -17,6 +17,7 @@ import { useHasMultipleCameras } from "@/src/hooks/use-has-multiple-cameras";
 import { useMeetStore } from "@/src/stores/meet";
 import { useJoinMeetStore } from "@/src/stores/joinMeet";
 import { avatarColor, initialsOf } from "@/src/lib/avatar";
+import { fetchIceServers } from "@/src/services/api/ice";
 
 export default function JoinMeet() {
     const params = useParams<{ meetCode: string }>();
@@ -28,12 +29,19 @@ export default function JoinMeet() {
     const [showSettings, setShowSettings] = useState(false);
     useEffect(() => { setCanShare('share' in navigator); }, []);
 
-    const { localStream, enableMic, disableMic, enableCamera, disableCamera, switchCamera } = usePeerStore();
+    const { localStream, enableMic, disableMic, enableCamera, disableCamera, switchCamera, setIceServers } = usePeerStore();
     const hasMultipleCameras = useHasMultipleCameras();
     const { isMuted, isVideoOff, toggleMute, toggleVideo } = useMeetStore();
     const { userName, setUserName, setMeetCode: setStoredMeetCode, setHasJoinedMeet } = useJoinMeetStore();
 
     useEffect(() => { setMeetCode(params.meetCode); }, [params]);
+
+    useEffect(() => {
+        fetchIceServers()
+            .then(setIceServers)
+            .catch(() => { /* will retry inside use-call on join */ });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     useEffect(() => {
         if (videoRef.current) videoRef.current.srcObject = localStream;

--- a/src/hooks/use-call.ts
+++ b/src/hooks/use-call.ts
@@ -186,14 +186,17 @@ export function useCall({ client, roomId, enabled, userName, initialAudio, initi
 
     ;(async () => {
       try {
-        let iceServers: Awaited<ReturnType<typeof fetchIceServers>> = []
-        try {
-          iceServers = await fetchIceServers()
-        } catch (e) {
-          console.warn('ICE server fetch failed, proceeding without TURN', e)
+        // Skip fetch if ICE servers were pre-fetched on the join screen.
+        if (store.getState().iceServers.length === 0) {
+          try {
+            const iceServers = await fetchIceServers()
+            if (disposed) return
+            store.getState().setIceServers(iceServers)
+          } catch (e) {
+            console.warn('ICE server fetch failed, proceeding without TURN', e)
+          }
         }
         if (disposed) return
-        store.getState().setIceServers(iceServers)
         const a = joinArgs.current
         client.send('join', { name: a.userName, audio: a.initialAudio, video: a.initialVideo }, { room: roomId })
       } catch (e) {


### PR DESCRIPTION
Start fetching TURN credentials as soon as JoinMeet mounts so they are in the store by the time the user clicks Join. use-call skips the fetch when servers are already loaded, eliminating the window where a peer connection could be created without TURN credentials on symmetric NAT.