### PR TITLE
test: add coverage for use-peer-stats, background-blur, and ice API

### DIFF
--- a/src/hooks/__tests__/use-peer-stats.test.ts
+++ b/src/hooks/__tests__/use-peer-stats.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest'
+import { parseReport, stepAdaptation, type PrevEntry } from '../use-peer-stats'
+import type { EncodingLevel } from '@/src/stores/peer'
+import type Peer from 'simple-peer'
+
+// ─── parseReport ──────────────────────────────────────────────────────────────
+
+function makeReport(entries: Array<{ id?: string } & Record<string, unknown>>): RTCStatsReport {
+    const map = new Map<string, unknown>()
+    entries.forEach((e, i) => {
+        // Use the entry's own `id` as the map key so report.get(candidateId) resolves correctly.
+        map.set(typeof e.id === 'string' ? e.id : String(i), e)
+    })
+    return map as unknown as RTCStatsReport
+}
+
+describe('parseReport – quality classification', () => {
+    it('classifies "good" when loss < 2% and RTT < 150ms', () => {
+        const report = makeReport([
+            { type: 'candidate-pair', nominated: true, currentRoundTripTime: 0.05, localCandidateId: '1' },
+            { type: 'candidate', id: '1', candidateType: 'host' },
+            { type: 'remote-inbound-rtp', fractionLost: 0.005 },
+        ])
+        const stats = parseReport(report, 'peer1', new Map(), 2)
+        expect(stats.quality).toBe('good')
+    })
+
+    it('classifies "medium" when loss is moderate or RTT is elevated', () => {
+        const report = makeReport([
+            { type: 'candidate-pair', nominated: true, currentRoundTripTime: 0.2, localCandidateId: '1' },
+            { type: 'remote-inbound-rtp', fractionLost: 0.04 },
+        ])
+        const stats = parseReport(report, 'peer1', new Map(), 2)
+        expect(stats.quality).toBe('medium')
+    })
+
+    it('classifies "poor" when loss >= 8% or RTT >= 400ms', () => {
+        const report = makeReport([
+            { type: 'candidate-pair', nominated: true, currentRoundTripTime: 0.5, localCandidateId: '1' },
+            { type: 'remote-inbound-rtp', fractionLost: 0.1 },
+        ])
+        const stats = parseReport(report, 'peer1', new Map(), 2)
+        expect(stats.quality).toBe('poor')
+    })
+
+    it('returns quality "unknown" when no RTT data is available', () => {
+        const report = makeReport([])
+        const stats = parseReport(report, 'peer1', new Map(), 2)
+        expect(stats.quality).toBe('unknown')
+        expect(stats.roundTripTimeMs).toBe(-1)
+    })
+
+    it('detects relay candidate type from localCandidateId', () => {
+        const report = makeReport([
+            { type: 'candidate-pair', nominated: true, currentRoundTripTime: 0.05, localCandidateId: 'c1' },
+            { id: 'c1', type: 'local-candidate', candidateType: 'relay' },
+        ])
+        const stats = parseReport(report, 'peer1', new Map(), 2)
+        expect(stats.candidateType).toBe('relay')
+    })
+
+    it('computes bitrate from prev/current byte delta', () => {
+        const prevMap = new Map<string, PrevEntry>()
+        const now = Date.now()
+        prevMap.set('peer1', { bytesSent: 0, bytesReceived: 0, ts: now - 1000 })
+
+        const report = makeReport([
+            { type: 'outbound-rtp', bytesSent: 125_000 },   // 125 KB in 1 s = 1000 kbps
+            { type: 'inbound-rtp', bytesReceived: 62_500 },  // 62.5 KB in 1 s = 500 kbps
+        ])
+
+        const stats = parseReport(report, 'peer1', prevMap, 2)
+        // Allow ±50 kbps tolerance for timing jitter in tests
+        expect(stats.outboundBitrateKbps).toBeGreaterThan(900)
+        expect(stats.inboundBitrateKbps).toBeGreaterThan(450)
+    })
+
+    it('passes through video frame metrics', () => {
+        const report = makeReport([
+            { type: 'candidate-pair', nominated: true, currentRoundTripTime: 0.05 },
+            { type: 'inbound-rtp', kind: 'video', bytesReceived: 0, jitter: 0.01,
+              frameWidth: 1280, frameHeight: 720, framesPerSecond: 29.7 },
+        ])
+        const stats = parseReport(report, 'peer1', new Map(), 2)
+        expect(stats.frameWidth).toBe(1280)
+        expect(stats.frameHeight).toBe(720)
+        expect(stats.framesPerSecond).toBe(30) // Math.round(29.7)
+        expect(stats.jitterMs).toBe(10)        // 0.01 * 1000
+    })
+})
+
+// ─── stepAdaptation ──────────────────────────────────────────────────────────
+
+function makePeer(): Peer.Instance {
+    return {
+        destroyed: false,
+        _pc: {
+            getSenders: vi.fn(() => [
+                { track: { kind: 'video' }, getParameters: vi.fn(() => ({ encodings: [{}] })), setParameters: vi.fn().mockResolvedValue(undefined) },
+            ]),
+        },
+    } as unknown as Peer.Instance
+}
+
+describe('stepAdaptation – encoding level stepping', () => {
+    it('steps down after STEP_DOWN_SAMPLES consecutive high-loss polls', () => {
+        const levels = new Map<string, EncodingLevel>()
+        const bad    = new Map<string, number>()
+        const good   = new Map<string, number>()
+        const peer   = makePeer()
+
+        // First bad sample — should not step yet
+        let level = stepAdaptation('p1', peer, 10, levels, bad, good)
+        expect(level).toBe(2)
+
+        // Second bad sample — should step down to 1
+        level = stepAdaptation('p1', peer, 10, levels, bad, good)
+        expect(level).toBe(1)
+    })
+
+    it('steps up after STEP_UP_SAMPLES consecutive clean polls', () => {
+        const levels = new Map<string, EncodingLevel>([['p1', 0 as EncodingLevel]])
+        const bad    = new Map<string, number>()
+        const good   = new Map<string, number>()
+        const peer   = makePeer()
+
+        for (let i = 0; i < 4; i++) {
+            const level = stepAdaptation('p1', peer, 0, levels, bad, good)
+            expect(level).toBe(0) // not stepped yet
+        }
+
+        // 5th clean sample — should step up to 1
+        const level = stepAdaptation('p1', peer, 0, levels, bad, good)
+        expect(level).toBe(1)
+    })
+
+    it('holds level in the middle band (1% ≤ loss < 5%) and resets counters', () => {
+        const levels = new Map<string, EncodingLevel>([['p1', 1 as EncodingLevel]])
+        const bad    = new Map<string, number>([['p1', 3]])
+        const good   = new Map<string, number>([['p1', 3]])
+        const peer   = makePeer()
+
+        const level = stepAdaptation('p1', peer, 3, levels, bad, good)
+        expect(level).toBe(1)
+        expect(bad.get('p1')).toBe(0)
+        expect(good.get('p1')).toBe(0)
+    })
+
+    it('does not step below level 0', () => {
+        const levels = new Map<string, EncodingLevel>([['p1', 0 as EncodingLevel]])
+        const bad    = new Map<string, number>([['p1', 10]])
+        const good   = new Map<string, number>()
+        const peer   = makePeer()
+
+        const level = stepAdaptation('p1', peer, 20, levels, bad, good)
+        expect(level).toBe(0)
+    })
+
+    it('does not step above level 2', () => {
+        const levels = new Map<string, EncodingLevel>([['p1', 2 as EncodingLevel]])
+        const bad    = new Map<string, number>()
+        const good   = new Map<string, number>([['p1', 10]])
+        const peer   = makePeer()
+
+        const level = stepAdaptation('p1', peer, 0, levels, bad, good)
+        expect(level).toBe(2)
+    })
+})

--- a/src/hooks/use-peer-stats.ts
+++ b/src/hooks/use-peer-stats.ts
@@ -55,7 +55,7 @@ async function applyEncodingLevel(peer: Peer.Instance, level: EncodingLevel) {
 
 // ─── Stats parsing ─────────────────────────────────────────────────────────────
 
-interface PrevEntry { bytesSent: number; bytesReceived: number; ts: number }
+export interface PrevEntry { bytesSent: number; bytesReceived: number; ts: number }
 
 // RTCStatsReport entries are loosely typed in the DOM lib.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -65,7 +65,7 @@ function n(entry: StatsEntry, key: string): number {
   return typeof entry[key] === 'number' ? entry[key] : 0
 }
 
-function parseReport(
+export function parseReport(
   report: RTCStatsReport,
   peerId: string,
   prevMap: Map<string, PrevEntry>,
@@ -158,7 +158,7 @@ function parseReport(
 
 // ─── Adaptive step function ───────────────────────────────────────────────────
 
-function stepAdaptation(
+export function stepAdaptation(
   peerId: string,
   peer: Peer.Instance,
   loss: number,

--- a/src/lib/__tests__/background-blur.test.ts
+++ b/src/lib/__tests__/background-blur.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BackgroundBlurProcessor } from '../background-blur'
+
+// MediaPipe is a CDN-loaded WASM module — stub it out entirely.
+vi.mock('@mediapipe/tasks-vision', () => ({
+    FilesetResolver: {
+        forVisionTasks: vi.fn().mockResolvedValue({}),
+    },
+    ImageSegmenter: {
+        createFromOptions: vi.fn().mockResolvedValue({
+            segmentForVideo: vi.fn(),
+        }),
+    },
+}))
+
+// jsdom does not implement MediaStream — provide a minimal stub.
+if (typeof globalThis.MediaStream === 'undefined') {
+    globalThis.MediaStream = class {
+        constructor(public tracks: MediaStreamTrack[] = []) {}
+    } as unknown as typeof MediaStream
+}
+
+// Capture original before any spy is installed to avoid recursive mock calls.
+const origCreateElement = document.createElement.bind(document)
+
+function makeTrack(width = 640, height = 480): MediaStreamTrack {
+    return {
+        getSettings: () => ({ width, height }),
+        kind: 'video',
+    } as unknown as MediaStreamTrack
+}
+
+function makeCanvasTrack(): MediaStreamTrack {
+    return { kind: 'video', stop: vi.fn() } as unknown as MediaStreamTrack
+}
+
+describe('BackgroundBlurProcessor', () => {
+    let processor: BackgroundBlurProcessor
+
+    beforeEach(() => {
+        processor = new BackgroundBlurProcessor()
+
+        vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+            if (tag === 'video') {
+                // Use the captured original so we don't recurse into the spy.
+                const video = origCreateElement('video') as HTMLVideoElement
+                vi.spyOn(video, 'play').mockResolvedValue(undefined)
+                Object.defineProperty(video, 'readyState', { value: 4, writable: true })
+                return video as unknown as HTMLElement
+            }
+            if (tag === 'canvas') {
+                const canvas = origCreateElement('canvas') as HTMLCanvasElement
+                canvas.captureStream = vi.fn().mockReturnValue({
+                    getVideoTracks: () => [makeCanvasTrack()],
+                })
+                const ctx = {
+                    filter: '',
+                    drawImage: vi.fn(),
+                    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(640 * 480 * 4) })),
+                    putImageData: vi.fn(),
+                    canvas,
+                }
+                vi.spyOn(canvas, 'getContext').mockReturnValue(ctx as unknown as CanvasRenderingContext2D)
+                return canvas as unknown as HTMLElement
+            }
+            return origCreateElement(tag)
+        })
+    })
+
+    it('stop() is safe to call when never started', () => {
+        expect(() => processor.stop()).not.toThrow()
+    })
+
+    it('stop() clears the interval after start()', async () => {
+        const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+
+        await processor.start(makeTrack())
+        processor.stop()
+
+        expect(clearSpy).toHaveBeenCalled()
+    })
+
+    it('stop() is idempotent — second call does not throw', async () => {
+        await processor.start(makeTrack())
+        processor.stop()
+        expect(() => processor.stop()).not.toThrow()
+    })
+
+    it('start() returns a video track from captureStream', async () => {
+        const track = await processor.start(makeTrack())
+        expect(track.kind).toBe('video')
+    })
+
+    it('start() resolves for non-default track dimensions', async () => {
+        await expect(processor.start(makeTrack(1280, 720))).resolves.toBeDefined()
+    })
+})

--- a/src/services/api/__tests__/ice.test.ts
+++ b/src/services/api/__tests__/ice.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchIceServers } from '../ice'
+
+describe('fetchIceServers', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns iceServers from a successful response', async () => {
+        const servers = [
+            { urls: ['stun:stun.example.com'] },
+            { urls: ['turn:turn.example.com'], username: 'user', credential: 'pass' },
+        ]
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ iceServers: servers }),
+        }))
+
+        const result = await fetchIceServers()
+
+        expect(result).toEqual(servers)
+    })
+
+    it('throws when the server returns a non-ok status', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: false,
+            status: 503,
+        }))
+
+        await expect(fetchIceServers()).rejects.toThrow('ice-servers failed: 503')
+    })
+
+    it('throws when fetch itself rejects (network error)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
+
+        await expect(fetchIceServers()).rejects.toThrow('network error')
+    })
+})


### PR DESCRIPTION
Export parseReport and stepAdaptation from use-peer-stats for unit testing. Add tests for quality classification, bitrate computation, relay detection, and adaptive encoding step-up/step-down logic. Add BackgroundBlurProcessor tests covering start/stop lifecycle and idempotent cleanup. Add fetchIceServers tests for success, HTTP error, and network failure paths.