### PR TITLE
feat: device picker — mic, camera, speaker selection with live switching

### DIFF
--- a/src/components/ui/SettingsPanel.tsx
+++ b/src/components/ui/SettingsPanel.tsx
@@ -8,6 +8,8 @@ import {
   type BackgroundEffectPreference,
 } from '@/src/lib/background-effects'
 import { usePeerStore } from '@/src/stores/peer'
+import { useMediaDevices } from '@/src/hooks/use-media-devices'
+import { supportsAudioOutputSelection } from '@/src/lib/audio-context'
 
 interface SettingsPanelProps {
   onClose: () => void
@@ -163,8 +165,45 @@ function BackgroundEffectsGrid({ onChange }: { onChange: (pref: BackgroundEffect
   )
 }
 
+interface DeviceRowProps {
+  label: string
+  devices: { deviceId: string; label: string }[]
+  value: string
+  onChange: (deviceId: string) => void
+}
+
+function DeviceRow({ label, devices, value, onChange }: DeviceRowProps) {
+  if (devices.length === 0) return null
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs text-[hsl(var(--muted-foreground))]">{label}</span>
+      <select
+        value={value || devices[0]?.deviceId}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full cursor-pointer appearance-none rounded-lg border border-[hsl(var(--border))]
+                   bg-[hsl(var(--surface-2))] px-3 py-2 text-sm text-[hsl(var(--foreground))]
+                   focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))/0.6]"
+      >
+        {devices.map((d) => (
+          <option key={d.deviceId} value={d.deviceId}>
+            {d.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
 export function SettingsPanel({ onClose, isVideoOff }: SettingsPanelProps) {
   const setBackgroundEffect = usePeerStore((s) => s.setBackgroundEffect)
+  const setAudioInput = usePeerStore((s) => s.setAudioInput)
+  const setVideoInput = usePeerStore((s) => s.setVideoInput)
+  const setAudioOutput = usePeerStore((s) => s.setAudioOutput)
+  const preferredAudioInputId = usePeerStore((s) => s.preferredAudioInputId)
+  const preferredVideoInputId = usePeerStore((s) => s.preferredVideoInputId)
+  const preferredAudioOutputId = usePeerStore((s) => s.preferredAudioOutputId)
+  const { audioInputs, videoInputs, audioOutputs } = useMediaDevices()
+  const showSpeaker = supportsAudioOutputSelection() && audioOutputs.length > 0
 
   return (
     <aside
@@ -202,6 +241,37 @@ export function SettingsPanel({ onClose, isVideoOff }: SettingsPanelProps) {
               <BackgroundEffectsGrid onChange={(pref) => { void setBackgroundEffect(pref) }} />
             )}
           </section>
+
+          {/* ── Devices ────────────────────────────────── */}
+          {(audioInputs.length > 0 || videoInputs.length > 0 || showSpeaker) && (
+            <section className="flex flex-col gap-3">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-[hsl(var(--muted-foreground))]">
+                Devices
+              </h2>
+              <div className="flex flex-col gap-3">
+                <DeviceRow
+                  label="Microphone"
+                  devices={audioInputs}
+                  value={preferredAudioInputId}
+                  onChange={(id) => { void setAudioInput(id) }}
+                />
+                <DeviceRow
+                  label="Camera"
+                  devices={videoInputs}
+                  value={preferredVideoInputId}
+                  onChange={(id) => { void setVideoInput(id) }}
+                />
+                {showSpeaker && (
+                  <DeviceRow
+                    label="Speaker"
+                    devices={audioOutputs}
+                    value={preferredAudioOutputId}
+                    onChange={(id) => { void setAudioOutput(id) }}
+                  />
+                )}
+              </div>
+            </section>
+          )}
 
         </div>
     </aside>

--- a/src/hooks/use-media-devices.ts
+++ b/src/hooks/use-media-devices.ts
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export interface MediaDeviceSummary {
+  deviceId: string
+  label: string
+}
+
+export interface AvailableDevices {
+  audioInputs: MediaDeviceSummary[]
+  videoInputs: MediaDeviceSummary[]
+  audioOutputs: MediaDeviceSummary[]
+}
+
+const EMPTY: AvailableDevices = { audioInputs: [], videoInputs: [], audioOutputs: [] }
+
+function toSummary(d: MediaDeviceInfo, fallback: string): MediaDeviceSummary {
+  return { deviceId: d.deviceId, label: d.label || fallback }
+}
+
+async function enumerate(): Promise<AvailableDevices> {
+  if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) return EMPTY
+  try {
+    const all = await navigator.mediaDevices.enumerateDevices()
+    return {
+      audioInputs: all.filter(d => d.kind === 'audioinput').map((d, i) => toSummary(d, `Microphone ${i + 1}`)),
+      videoInputs: all.filter(d => d.kind === 'videoinput').map((d, i) => toSummary(d, `Camera ${i + 1}`)),
+      audioOutputs: all.filter(d => d.kind === 'audiooutput').map((d, i) => toSummary(d, `Speaker ${i + 1}`)),
+    }
+  } catch { return EMPTY }
+}
+
+// Enumerates available media devices and re-enumerates on devicechange events.
+// Labels are populated only after the user has granted mic/camera permission.
+export function useMediaDevices(): AvailableDevices {
+  const [devices, setDevices] = useState<AvailableDevices>(EMPTY)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const refresh = () => {
+      enumerate().then(d => { if (!cancelled) setDevices(d) })
+    }
+
+    refresh()
+    navigator.mediaDevices?.addEventListener('devicechange', refresh)
+    return () => {
+      cancelled = true
+      navigator.mediaDevices?.removeEventListener('devicechange', refresh)
+    }
+  }, [])
+
+  return devices
+}

--- a/src/lib/audio-context.ts
+++ b/src/lib/audio-context.ts
@@ -3,7 +3,11 @@
 // satisfy iOS Safari's autoplay policy. Desktop Chrome/Firefox are lenient,
 // but we share anyway to avoid the per-tile overhead.
 
+type AudioContextWithSinkId = AudioContext & { setSinkId: (id: string) => Promise<void> }
+
 let sharedCtx: AudioContext | null = null
+// Preserved across context recreations so a new context gets the right output.
+let pendingSinkId: string | null = null
 
 function getAudioCtor(): typeof AudioContext | null {
   if (typeof window === 'undefined') return null
@@ -19,6 +23,9 @@ export function getSharedAudioContext(): AudioContext | null {
   if (!Ctor) return null
   if (!sharedCtx || sharedCtx.state === 'closed') {
     sharedCtx = new Ctor({ latencyHint: 'interactive', sampleRate: 48000 })
+    if (pendingSinkId && 'setSinkId' in sharedCtx) {
+      ;(sharedCtx as AudioContextWithSinkId).setSinkId(pendingSinkId).catch(() => {})
+    }
   }
   return sharedCtx
 }
@@ -28,4 +35,22 @@ export function getSharedAudioContext(): AudioContext | null {
 export function resumeSharedAudioContext(): void {
   const ctx = getSharedAudioContext()
   if (ctx && ctx.state === 'suspended') ctx.resume().catch(() => {})
+}
+
+// Routes all AudioContext output to the given device. Chrome 110+ only;
+// silently no-ops on unsupported browsers.
+export async function setAudioOutputDevice(deviceId: string): Promise<void> {
+  pendingSinkId = deviceId
+  const ctx = getSharedAudioContext()
+  if (!ctx || !('setSinkId' in ctx)) return
+  try {
+    await (ctx as AudioContextWithSinkId).setSinkId(deviceId)
+  } catch (e) {
+    console.warn('[AudioContext] setSinkId failed', e)
+  }
+}
+
+// True only on Chrome 110+ and other browsers that implement AudioContext.setSinkId.
+export function supportsAudioOutputSelection(): boolean {
+  return typeof window !== 'undefined' && 'setSinkId' in AudioContext.prototype
 }

--- a/src/lib/device-preferences.ts
+++ b/src/lib/device-preferences.ts
@@ -1,0 +1,26 @@
+const STORAGE_KEY = 'vartalaap:devices'
+
+interface DevicePrefs {
+  audioInputId?: string
+  videoInputId?: string
+  audioOutputId?: string
+}
+
+export function getDevicePreferences(): DevicePrefs {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as DevicePrefs) : {}
+  } catch { return {} }
+}
+
+export function setDevicePreference(
+  key: keyof DevicePrefs,
+  deviceId: string,
+): void {
+  if (typeof window === 'undefined') return
+  try {
+    const prefs = getDevicePreferences()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...prefs, [key]: deviceId }))
+  } catch { /* non-critical */ }
+}

--- a/src/stores/peer.ts
+++ b/src/stores/peer.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import Peer from 'simple-peer'
 import type { IceServer } from '@/src/services/api/ice'
-import { getSharedAudioContext } from '@/src/lib/audio-context'
+import { getSharedAudioContext, setAudioOutputDevice } from '@/src/lib/audio-context'
 import { BackgroundBlurProcessor } from '@/src/lib/background-blur'
 import { getMicConstraints } from '@/src/lib/audio-constraints'
 import {
@@ -11,6 +11,7 @@ import {
   type BackgroundEffectMode,
   type BackgroundEffectPreference,
 } from '@/src/lib/background-effects'
+import { getDevicePreferences, setDevicePreference } from '@/src/lib/device-preferences'
 
 const VIDEO_WIDTH_IDEAL = 960
 const VIDEO_HEIGHT_IDEAL = 540
@@ -57,6 +58,9 @@ interface PeerState {
   backgroundEffect: BackgroundEffectMode
   backgroundImageDataUrl: string | null
   facingMode: 'user' | 'environment'
+  preferredAudioInputId: string
+  preferredVideoInputId: string
+  preferredAudioOutputId: string
   peerConnections: Map<string, PeerConnection>
   peerStats: Map<string, PeerStats>
   iceServers: IceServer[]
@@ -78,6 +82,10 @@ interface PeerState {
   enableCamera: () => Promise<MediaStreamTrack | null>
   disableCamera: () => void
   switchCamera: () => Promise<boolean>
+
+  setAudioInput: (deviceId: string) => Promise<void>
+  setVideoInput: (deviceId: string) => Promise<void>
+  setAudioOutput: (deviceId: string) => Promise<void>
 
   setBackgroundEffect: (preference: BackgroundEffectPreference) => Promise<boolean>
   setBackgroundBlur: (enabled: boolean) => Promise<boolean>
@@ -248,7 +256,9 @@ const replaceAudioSenderOnPeers = (
 }
 
 export const usePeerStore = create<PeerState>()(
-  devtools((set, get) => ({
+  devtools((set, get) => {
+    const savedDevices = getDevicePreferences()
+    return {
     localStream: null,
     screenTrack: null,
     blurProcessor: null,
@@ -256,6 +266,9 @@ export const usePeerStore = create<PeerState>()(
     backgroundEffect: getBackgroundEffectPreference().mode,
     backgroundImageDataUrl: getBackgroundEffectPreference().imageDataUrl ?? null,
     facingMode: 'user',
+    preferredAudioInputId: savedDevices.audioInputId ?? '',
+    preferredVideoInputId: savedDevices.videoInputId ?? '',
+    preferredAudioOutputId: savedDevices.audioOutputId ?? '',
     peerConnections: new Map(),
     peerStats: new Map(),
     iceServers: [],
@@ -318,7 +331,12 @@ export const usePeerStore = create<PeerState>()(
 
     enableMic: async () => {
       try {
-        const media = await navigator.mediaDevices.getUserMedia({ audio: getMicConstraints() })
+        const { preferredAudioInputId } = get()
+        const audioConstraints: MediaTrackConstraints = {
+          ...getMicConstraints(),
+          ...(preferredAudioInputId ? { deviceId: { exact: preferredAudioInputId } } : {}),
+        }
+        const media = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints })
         const track = media.getAudioTracks()[0]
         if (!track) return null
         const existing = get().localStream
@@ -349,15 +367,11 @@ export const usePeerStore = create<PeerState>()(
 
     enableCamera: async () => {
       try {
-        const { facingMode, blurProcessor: activeProcessor, localStream: existingStream, backgroundEffect, backgroundImageDataUrl } = get()
-        const media = await getUserMediaWithFallback({
-          video: {
-            facingMode,
-            width: { ideal: VIDEO_WIDTH_IDEAL },
-            height: { ideal: VIDEO_HEIGHT_IDEAL },
-            frameRate: { ideal: VIDEO_FRAME_RATE_IDEAL },
-          },
-        })
+        const { facingMode, preferredVideoInputId, blurProcessor: activeProcessor, localStream: existingStream, backgroundEffect, backgroundImageDataUrl } = get()
+        const videoConstraints: MediaTrackConstraints = preferredVideoInputId
+          ? { deviceId: { exact: preferredVideoInputId }, width: { ideal: VIDEO_WIDTH_IDEAL }, height: { ideal: VIDEO_HEIGHT_IDEAL }, frameRate: { ideal: VIDEO_FRAME_RATE_IDEAL } }
+          : { facingMode, width: { ideal: VIDEO_WIDTH_IDEAL }, height: { ideal: VIDEO_HEIGHT_IDEAL }, frameRate: { ideal: VIDEO_FRAME_RATE_IDEAL } }
+        const media = await getUserMediaWithFallback({ video: videoConstraints })
         const track = media.getVideoTracks()[0]
         if (!track) return null
 
@@ -473,6 +487,66 @@ export const usePeerStore = create<PeerState>()(
         console.error('switchCamera failed', e)
         return false
       }
+    },
+
+    setAudioInput: async (deviceId) => {
+      setDevicePreference('audioInputId', deviceId)
+      set({ preferredAudioInputId: deviceId })
+      const { localStream, peerConnections } = get()
+      if (!localStream?.getAudioTracks().length) return
+      try {
+        const audioConstraints: MediaTrackConstraints = {
+          ...getMicConstraints(),
+          deviceId: { exact: deviceId },
+        }
+        const media = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints })
+        const track = media.getAudioTracks()[0]
+        if (!track) return
+        localStream.getAudioTracks().forEach(t => { t.stop(); localStream.removeTrack(t) })
+        localStream.addTrack(track)
+        replaceAudioSenderOnPeers(track, peerConnections)
+      } catch (e) {
+        console.error('setAudioInput failed', e)
+      }
+    },
+
+    setVideoInput: async (deviceId) => {
+      setDevicePreference('videoInputId', deviceId)
+      set({ preferredVideoInputId: deviceId })
+      const { localStream, peerConnections, blurProcessor: activeProcessor, backgroundEffect, backgroundImageDataUrl } = get()
+      if (!localStream?.getVideoTracks().length) return
+      try {
+        const media = await navigator.mediaDevices.getUserMedia({
+          video: { deviceId: { exact: deviceId }, width: { ideal: VIDEO_WIDTH_IDEAL }, height: { ideal: VIDEO_HEIGHT_IDEAL }, frameRate: { ideal: VIDEO_FRAME_RATE_IDEAL } },
+        })
+        const newTrack = media.getVideoTracks()[0]
+        if (!newTrack) return
+        const audioTracks = localStream.getAudioTracks()
+        localStream.getVideoTracks().forEach(t => t.stop())
+        if (activeProcessor) {
+          activeProcessor.stop()
+          try {
+            const newProcessor = createBackgroundProcessor({ mode: backgroundEffect, imageDataUrl: backgroundImageDataUrl ?? undefined })
+            if (newProcessor) {
+              const canvasTrack = await newProcessor.start(newTrack)
+              set({ localStream: new MediaStream([...audioTracks, canvasTrack]), blurProcessor: newProcessor, rawCameraTrack: newTrack })
+              replaceVideoTrackOnPeers(canvasTrack, peerConnections)
+              return
+            }
+          } catch { /* fall through to raw track */ }
+          set({ blurProcessor: null, rawCameraTrack: null })
+        }
+        set({ localStream: new MediaStream([...audioTracks, newTrack]) })
+        replaceVideoTrackOnPeers(newTrack, peerConnections)
+      } catch (e) {
+        console.error('setVideoInput failed', e)
+      }
+    },
+
+    setAudioOutput: async (deviceId) => {
+      setDevicePreference('audioOutputId', deviceId)
+      set({ preferredAudioOutputId: deviceId })
+      await setAudioOutputDevice(deviceId)
     },
 
     setBackgroundEffect: async (preference) => {
@@ -617,5 +691,6 @@ export const usePeerStore = create<PeerState>()(
         peerStats: new Map(),
       })
     },
-  })),
+  }
+  }),
 )


### PR DESCRIPTION
Adds per-device selection to the Settings panel. Devices are enumerated via enumerateDevices(), persisted to localStorage (vartalaap:devices), and applied immediately via replaceTrack without renegotiation. Speaker routing uses AudioContext.setSinkId (Chrome 110+) on the shared WebAudio context; the selector is hidden on unsupported browsers.