### PR TITLE
Keep SFU auth alive for the whole call; preflight dead sessions in the lobby

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,7 +7,7 @@ import { BufferingButtonLabel } from "@/src/components/ui/BufferingButtonLabel";
 import { Input } from "@/src/components/ui/input";
 import { Button } from "@/src/components/ui/button";
 import { StandaloneHeader } from "@/src/components/ui/StandaloneHeader";
-import { useLogin } from "@/src/hooks/use-auth";
+import { useLogin, safeNextPath } from "@/src/hooks/use-auth";
 import { useAuthStore } from "@/src/stores/auth";
 
 export default function Login() {
@@ -18,7 +18,7 @@ export default function Login() {
 
     useEffect(() => {
         if (!isLoading && isAuthenticated && user) {
-            router.replace(user.onboardingStep < 5 ? "/onboarding" : "/dashboard");
+            router.replace(user.onboardingStep < 5 ? "/onboarding" : safeNextPath() ?? "/dashboard");
         }
     }, [isLoading, isAuthenticated, user, router]);
     const { mutate: login, isPending } = useLogin();

--- a/src/components/features/JoinMeet.tsx
+++ b/src/components/features/JoinMeet.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { Copy, Check, Share2, Settings, Loader2, Clock, CalendarOff } from "lucide-react";
+import { Copy, Check, Share2, Settings, Loader2, Clock, CalendarOff, LogIn } from "lucide-react";
 import { fetchRoomStatus, type RoomStatusResult } from "@/src/services/api/room";
+import { getMe } from "@/src/services/api/auth";
+import { getAccessToken } from "@/src/services/api/token";
+import { useAuthStore } from "@/src/stores/auth";
 import { SettingsPanel } from "@/src/components/ui/SettingsPanel";
 import { resumeSharedAudioContext } from "@/src/lib/audio-context";
 import { playJoinCall } from "@/src/lib/sounds";
@@ -38,6 +41,7 @@ export default function JoinMeet() {
     const [canShare, setCanShare] = useState(false);
     const [showSettings, setShowSettings] = useState(false);
     const [isJoining, setIsJoining] = useState(false);
+    const [sessionExpired, setSessionExpired] = useState(false);
     const [roomStatus, setRoomStatus] = useState<RoomStatusResult | null>(null);
     const [statusChecked, setStatusChecked] = useState(false);
     const canJoinMeet = meetCodePattern.test(params.meetCode);
@@ -112,15 +116,50 @@ export default function JoinMeet() {
         toggleMute();
     };
 
-    const handleJoin = () => {
-        const name = joinName.trim();
-        if (!name || !canJoinMeet || isJoining) return;
-        setIsJoining(true);
+    const proceedJoin = (name: string) => {
         setUserName(name);
         setStoredMeetCode(params.meetCode);
         resumeSharedAudioContext();
         playJoinCall();
         setHasJoinedMeet(true);
+    };
+
+    const handleJoin = async () => {
+        const name = joinName.trim();
+        if (!name || !canJoinMeet || isJoining) return;
+        setIsJoining(true);
+
+        // Preflight: if this user looks logged in, make sure the session is
+        // actually alive BEFORE entering the call. getMe() transparently
+        // refreshes an expired access token; it only fails when the refresh
+        // cookie itself is dead. Catching that here means the user chooses
+        // (sign in / join as guest) in the lobby instead of sitting in a call
+        // where the SFU silently rejects every request. A transient server
+        // error must not block joining — only a confirmed-dead session does
+        // (the failed refresh clears the stored token).
+        if (getAccessToken()) {
+            try {
+                await getMe();
+            } catch {
+                if (!getAccessToken()) {
+                    setIsJoining(false);
+                    setSessionExpired(true);
+                    return;
+                }
+            }
+        }
+
+        proceedJoin(name);
+    };
+
+    const handleContinueAsGuest = () => {
+        // The dead token is already cleared; reset the auth UI state so the
+        // join flow treats us as a guest (name input + knock/admit path).
+        const name = joinName.trim();
+        useAuthStore.getState().logout();
+        setSessionExpired(false);
+        setIsJoining(true);
+        proceedJoin(name);
     };
 
     const handleShare = async () => {
@@ -291,6 +330,13 @@ export default function JoinMeet() {
                             ) : roomStatus && roomStatus.status !== 'open' && roomStatus.status !== 'unavailable' ? (
                                 /* Room is not accessible — show a clear reason */
                                 <RoomStatusCard status={roomStatus} />
+                            ) : sessionExpired ? (
+                                /* Signed-in session can no longer be renewed — let the
+                                   user pick a path instead of failing inside the call. */
+                                <SessionExpiredCard
+                                    meetCode={params.meetCode}
+                                    onContinueAsGuest={handleContinueAsGuest}
+                                />
                             ) : (
                                 <div className="mt-4 flex flex-col gap-3">
                                     {authLoading ? (
@@ -346,6 +392,36 @@ export default function JoinMeet() {
 
         {showSettings && <SettingsPanel onClose={() => setShowSettings(false)} isVideoOff={isVideoOff} />}
         </main>
+    );
+}
+
+function SessionExpiredCard({ meetCode, onContinueAsGuest }: {
+    meetCode: string;
+    onContinueAsGuest: () => void;
+}) {
+    return (
+        <div className="mt-4 flex flex-col gap-3">
+            <div className="rounded-xl border border-[hsl(var(--border))]/70 bg-[hsl(var(--surface-2))] p-4">
+                <div className="flex items-start gap-3">
+                    <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-[hsl(var(--surface-3))] text-[hsl(var(--muted-foreground))]">
+                        <LogIn className="size-4" />
+                    </span>
+                    <div className="min-w-0">
+                        <p className="text-sm font-semibold text-[hsl(var(--foreground))]">Your session has expired</p>
+                        <p className="mt-1 text-sm leading-5 text-[hsl(var(--muted-foreground))]">
+                            Sign in again to join with your profile, or continue as a guest —
+                            the host will be asked to let you in.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <Button asChild size="lg" className="w-full">
+                <a href={`/login?next=${encodeURIComponent(`/room/${meetCode}`)}`}>Sign in again</a>
+            </Button>
+            <Button onClick={onContinueAsGuest} variant="secondary" size="lg" className="w-full">
+                Continue as a guest
+            </Button>
+        </div>
     );
 }
 

--- a/src/hooks/__tests__/use-call-multi-peer.test.ts
+++ b/src/hooks/__tests__/use-call-multi-peer.test.ts
@@ -70,6 +70,7 @@ vi.mock('@/src/services/api/token', () => ({
   getAccessToken: vi.fn(() => 'test-access-token'),
   getRoomToken: vi.fn(() => null),
   setRoomToken: vi.fn(),
+  subscribeTokenChange: vi.fn(() => () => {}),
 }))
 
 vi.mock('@sentry/nextjs', () => ({

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -5,6 +5,17 @@ import { login, logout, register, restoreAuthSession, getMe } from '@/src/servic
 import { useAuthStore } from '@/src/stores/auth'
 import type { RegisterCredentials, UserCredentials } from '@/src/types/auth'
 
+// Reads the ?next= return path from the current URL. Only internal absolute
+// paths are honored ("/room/abc") — anything else (full URLs, protocol-
+// relative "//evil.com") is dropped to keep this from becoming an open
+// redirect.
+export function safeNextPath(): string | null {
+    if (typeof window === 'undefined') return null
+    const next = new URLSearchParams(window.location.search).get('next')
+    if (!next || !next.startsWith('/') || next.startsWith('//') || next.includes('\\')) return null
+    return next
+}
+
 export const useLogin = () => {
     const { login: storeLogin } = useAuthStore()
     const router = useRouter()
@@ -13,8 +24,10 @@ export const useLogin = () => {
         mutationFn: (creds: UserCredentials) => login(creds),
         onSuccess: ({ user }) => {
             storeLogin(user)
-            // Resume onboarding if not complete
-            router.push(user.onboardingStep < 5 ? '/onboarding' : '/dashboard')
+            // Resume onboarding if not complete; otherwise honor a ?next=
+            // return path (e.g. back to the call a session-expired user was
+            // trying to join) before defaulting to the dashboard.
+            router.push(user.onboardingStep < 5 ? '/onboarding' : safeNextPath() ?? '/dashboard')
         },
         onError: (err: Error) => {
             toast.error(err.message || 'Login failed')

--- a/src/hooks/use-call.ts
+++ b/src/hooks/use-call.ts
@@ -10,6 +10,7 @@ import type {
   Envelope, ErrorData, JoinedData, KnockGrantedData, PeerJoinedData, PeerLeftData, PeerStateData, SfuTracksData,
 } from '@/src/services/signaling/protocol'
 import { SfuSession } from '@/src/services/webrtc/sfu-session'
+import { startSessionKeepalive } from '@/src/services/api/session-keepalive'
 import { playPeerJoined, playPeerLeft, playScreenShareStart, playScreenShareStop } from '@/src/lib/sounds'
 import { getAccessToken, getRoomToken, setRoomToken } from '@/src/services/api/token'
 import { useMeetStore } from '@/src/stores/meet'
@@ -42,6 +43,36 @@ export function useCall({ client, roomId, enabled, userName, initialAudio, initi
     callDebug.init()
     const store = usePeerStore
     let disposed = false
+
+    // Keep the access token fresh for the whole call. The SFU layer
+    // (partytracks) reads SfuSession's live auth header per request but has
+    // no 401→refresh path of its own — with a 15-minute access TTL, any call
+    // longer than that would otherwise start failing SFU requests silently.
+    // Guests (room token only) are a no-op here.
+    const stopKeepalive = startSessionKeepalive({
+      onSessionDead: () => {
+        if (disposed) return
+        // The call itself keeps working (media and signaling don't need the
+        // token) — but new SFU operations (a joiner's tracks, camera re-
+        // publish after failure) would 401. Tell the user while the call is
+        // still fine, with a one-click path back.
+        Sentry.captureMessage('session expired mid-call', {
+          level: 'warning',
+          tags: { stage: 'session_keepalive' },
+        })
+        import('sonner').then(({ toast }) => {
+          toast.error('Your session expired. Sign in again to keep everything working.', {
+            duration: Infinity,
+            action: {
+              label: 'Sign in',
+              onClick: () => {
+                window.location.href = `/login?next=${encodeURIComponent(window.location.pathname)}`
+              },
+            },
+          })
+        })
+      },
+    })
     const prevScreenSharing = new Map<string, boolean>()
     // Maps CF remoteSessionId → signaling peerId so onRemoteTrack can route tracks.
     const remoteSessionToPeer = new Map<string, string>()
@@ -619,6 +650,7 @@ export function useCall({ client, roomId, enabled, userName, initialAudio, initi
     return () => {
       client.send('leave', undefined, { room: roomId })
       disposed = true
+      stopKeepalive()
       // If the user navigated away before TTFM resolved, count it as abandoned —
       // not as success or timeout. Distinguishes "user gave up" from "we failed
       // to deliver" in the SLO breakdown.

--- a/src/services/api/__tests__/session-keepalive.test.ts
+++ b/src/services/api/__tests__/session-keepalive.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// refreshSession is the only auth.ts dependency — mocked so tests control
+// whether the "server" renews the session. The token module is real: the
+// keepalive's rescheduling runs off its change notifications, which is
+// exactly the behavior under test.
+const { refreshMock } = vi.hoisted(() => ({ refreshMock: vi.fn() }))
+vi.mock('../auth', () => ({ refreshSession: refreshMock }))
+
+import { startSessionKeepalive, jwtExpiryMs } from '../session-keepalive'
+import { setAccessToken } from '../token'
+
+function fakeJwt(expSecondsFromNow: number): string {
+    const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expSecondsFromNow }))
+    return `header.${payload}.sig`
+}
+
+beforeEach(() => {
+    vi.useFakeTimers()
+    refreshMock.mockReset()
+    setAccessToken(null)
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
+describe('jwtExpiryMs', () => {
+    it('decodes exp from a JWT payload', () => {
+        const token = fakeJwt(900)
+        const exp = jwtExpiryMs(token)
+        expect(exp).not.toBeNull()
+        expect(exp! - Date.now()).toBeGreaterThan(890_000)
+    })
+
+    it('returns null for garbage', () => {
+        expect(jwtExpiryMs('not-a-jwt')).toBeNull()
+        expect(jwtExpiryMs('a.b.c')).toBeNull()
+    })
+})
+
+describe('startSessionKeepalive', () => {
+    it('refreshes shortly before the token expires and reschedules on the new token', async () => {
+        setAccessToken(fakeJwt(900)) // 15 min
+        // Successful refresh: the real auth.ts sets the new token, which is
+        // what re-anchors the schedule — simulate that.
+        refreshMock.mockImplementation(async () => {
+            setAccessToken(fakeJwt(900))
+            return { accessToken: 'x', user: {} }
+        })
+        const onSessionDead = vi.fn()
+        const stop = startSessionKeepalive({ onSessionDead })
+
+        // 60s lead: nothing at 13 min, refresh by 14 min.
+        await vi.advanceTimersByTimeAsync(13 * 60_000)
+        expect(refreshMock).not.toHaveBeenCalled()
+        await vi.advanceTimersByTimeAsync(2 * 60_000)
+        expect(refreshMock).toHaveBeenCalledTimes(1)
+
+        // The renewed token schedules the NEXT refresh — proves the loop.
+        await vi.advanceTimersByTimeAsync(15 * 60_000)
+        expect(refreshMock).toHaveBeenCalledTimes(2)
+        expect(onSessionDead).not.toHaveBeenCalled()
+        stop()
+    })
+
+    it('fires onSessionDead exactly once when refresh fails', async () => {
+        setAccessToken(fakeJwt(30)) // already inside the refresh lead → immediate
+        refreshMock.mockImplementation(async () => {
+            setAccessToken(null) // real auth.ts clears the token on failure
+            return null
+        })
+        const onSessionDead = vi.fn()
+        const stop = startSessionKeepalive({ onSessionDead })
+
+        await vi.advanceTimersByTimeAsync(1_000)
+        expect(refreshMock).toHaveBeenCalledTimes(1)
+        expect(onSessionDead).toHaveBeenCalledTimes(1)
+
+        // Cleared token → no further schedule, no repeat notification.
+        await vi.advanceTimersByTimeAsync(60 * 60_000)
+        expect(onSessionDead).toHaveBeenCalledTimes(1)
+        stop()
+    })
+
+    it('is a no-op without an access token (guest with room token)', async () => {
+        const onSessionDead = vi.fn()
+        const stop = startSessionKeepalive({ onSessionDead })
+        await vi.advanceTimersByTimeAsync(60 * 60_000)
+        expect(refreshMock).not.toHaveBeenCalled()
+        expect(onSessionDead).not.toHaveBeenCalled()
+        stop()
+    })
+
+    it('stop() cancels the pending refresh', async () => {
+        setAccessToken(fakeJwt(900))
+        const stop = startSessionKeepalive({ onSessionDead: vi.fn() })
+        stop()
+        await vi.advanceTimersByTimeAsync(20 * 60_000)
+        expect(refreshMock).not.toHaveBeenCalled()
+    })
+})

--- a/src/services/api/session-keepalive.ts
+++ b/src/services/api/session-keepalive.ts
@@ -1,0 +1,83 @@
+/**
+ * Proactive access-token refresh for long-lived call sessions.
+ *
+ * apiFetch heals expired tokens reactively (401 → refresh → retry), but the
+ * SFU layer (partytracks) does its own fetches and cannot run that flow. With
+ * a 15-minute access TTL, any call longer than that would start failing SFU
+ * requests. Instead of intercepting those requests, we keep the token fresh
+ * the whole time a call is active: decode the JWT's exp and refresh shortly
+ * before it, so the live Authorization header SfuSession maintains is always
+ * valid and the user never sees auth at all.
+ *
+ * Guests hold only a room token (no refresh path) — for them this is a no-op.
+ */
+
+import { getAccessToken, subscribeTokenChange } from './token'
+import { refreshSession } from './auth'
+
+// Refresh this long before the token's exp. Generous enough to absorb a slow
+// /auth/refresh round-trip; far smaller than the 15-minute TTL.
+const REFRESH_LEAD_MS = 60_000
+
+// Decodes the exp claim (ms epoch) from a JWT without verifying it — the
+// server remains the authority; this is only used for scheduling.
+export function jwtExpiryMs(token: string): number | null {
+  try {
+    const payload = token.split('.')[1]
+    const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
+    const exp = (JSON.parse(json) as { exp?: number }).exp
+    return typeof exp === 'number' ? exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
+export interface SessionKeepaliveOptions {
+  // The refresh cookie is dead — the session cannot be renewed. Fired at most
+  // once per keepalive. The call keeps running (media and signaling don't
+  // need the token); the caller decides how to surface it.
+  onSessionDead: () => void
+}
+
+export function startSessionKeepalive(opts: SessionKeepaliveOptions): () => void {
+  let stopped = false
+  let deadNotified = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const clear = () => {
+    if (timer) { clearTimeout(timer); timer = null }
+  }
+
+  const schedule = () => {
+    clear()
+    if (stopped) return
+    const token = getAccessToken()
+    if (!token) return // guest (room token only) or signed out — nothing to keep alive
+    const expMs = jwtExpiryMs(token)
+    if (expMs === null) return
+    const delay = Math.max(0, expMs - Date.now() - REFRESH_LEAD_MS)
+    timer = setTimeout(() => {
+      void (async () => {
+        const resp = await refreshSession()
+        if (stopped) return
+        if (!resp && !deadNotified) {
+          deadNotified = true
+          opts.onSessionDead()
+        }
+        // On success, setAccessToken fires the token-change listener below,
+        // which reschedules against the new exp.
+      })()
+    }, delay)
+  }
+
+  // Any token change (our refresh, an apiFetch-triggered refresh elsewhere,
+  // re-login) re-anchors the schedule to the current token.
+  const unsubscribe = subscribeTokenChange(schedule)
+  schedule()
+
+  return () => {
+    stopped = true
+    clear()
+    unsubscribe()
+  }
+}

--- a/src/services/api/token.ts
+++ b/src/services/api/token.ts
@@ -14,6 +14,21 @@ let _token: string | null = null
 let _loaded = false
 let _roomToken: string | null = null
 
+// Listeners notified whenever either token slot changes. Long-lived consumers
+// that snapshot a token (SfuSession's live SFU auth headers, the in-call
+// session keepalive) subscribe here instead of polling.
+type TokenListener = () => void
+const tokenListeners = new Set<TokenListener>()
+
+export function subscribeTokenChange(listener: TokenListener): () => void {
+    tokenListeners.add(listener)
+    return () => tokenListeners.delete(listener)
+}
+
+function notifyTokenChange(): void {
+    for (const listener of tokenListeners) listener()
+}
+
 function readStoredAccessToken(): string | null {
     if (typeof window === 'undefined') return null
     try {
@@ -49,6 +64,7 @@ export function setAccessToken(token: string | null): void {
     _token = token
     _loaded = true
     writeStoredAccessToken(token)
+    notifyTokenChange()
 }
 
 export function getRoomToken(): string | null {
@@ -57,4 +73,5 @@ export function getRoomToken(): string | null {
 
 export function setRoomToken(token: string | null): void {
     _roomToken = token
+    notifyTokenChange()
 }

--- a/src/services/webrtc/__tests__/sfu-session.test.ts
+++ b/src/services/webrtc/__tests__/sfu-session.test.ts
@@ -52,14 +52,21 @@ vi.mock('partytracks/client', async () => {
 })
 
 vi.mock('@/src/services/api/config', () => ({ httpServerUri: 'http://test' }))
+
+// Mutable so tests can simulate a token refresh: SfuSession re-reads this via
+// its token-change subscription and must update its live Headers in place.
+const { authState } = vi.hoisted(() => ({ authState: { token: 'test-token' } }))
 vi.mock('@/src/services/api/fetch', () => ({
-    apiBearerHeaders: () => ({ Authorization: 'Bearer test-token' }),
+    apiBearerHeaders: () =>
+        authState.token ? { Authorization: `Bearer ${authState.token}` } : {},
 }))
 
 import { SfuSession } from '../sfu-session'
+import { setAccessToken } from '@/src/services/api/token'
 
 beforeEach(() => {
     instances.length = 0
+    authState.token = 'test-token'
 })
 
 function makeTrack(kind: 'audio' | 'video' = 'video'): MediaStreamTrack {
@@ -281,6 +288,42 @@ it('a push with no ack fires onPublishTimeout; an acked push does not', async ()
     } finally {
         vi.useRealTimers()
     }
+})
+
+// ─── Live SFU auth headers ────────────────────────────────────────────────
+// partytracks reads config.headers on EVERY request. SfuSession must keep
+// that Headers object current when the token refreshes — a header frozen at
+// construction goes stale after the 15-minute access TTL and turns every
+// later SFU request into a permanent 401 (the "joined but can't share or
+// receive anything" production incident).
+
+it('updates its live auth header in place when the token changes', () => {
+    const session = makeSession()
+    const config = instances[0].config as { headers: Headers }
+    expect(config.headers.get('Authorization')).toBe('Bearer test-token')
+
+    // Simulate a refresh: new token value, then the token-change notification
+    // that the real token store fires.
+    authState.token = 'refreshed-token'
+    setAccessToken('refreshed-token')
+    expect(config.headers.get('Authorization')).toBe('Bearer refreshed-token')
+
+    // Signed out mid-call: header is removed rather than sent stale.
+    authState.token = ''
+    setAccessToken(null)
+    expect(config.headers.get('Authorization')).toBeNull()
+    session.close()
+})
+
+// All PartyTracks instances (publish + per-peer subscribe) must share the
+// same live Headers object so one refresh fixes every connection.
+it('publish and subscribe PartyTracks share the same live Headers instance', async () => {
+    const session = makeSession()
+    await session.subscribe('cf-sess-bob', ['audio'])
+    const pubHeaders = (instances[0].config as { headers: Headers }).headers
+    const subHeaders = (instances[1].config as { headers: Headers }).headers
+    expect(subHeaders).toBe(pubHeaders)
+    session.close()
 })
 
 // A terminal push error must clear the dead pipeline so the next

--- a/src/services/webrtc/sfu-session.ts
+++ b/src/services/webrtc/sfu-session.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Subscription } from 'rxjs'
 import { PartyTracks, type TrackMetadata } from 'partytracks/client'
 import { httpServerUri } from '@/src/services/api/config'
 import { apiBearerHeaders } from '@/src/services/api/fetch'
+import { subscribeTokenChange } from '@/src/services/api/token'
 import type { SfuTracksData } from '@/src/services/signaling/protocol'
 import { callDebug } from '@/src/lib/call-debug'
 
@@ -112,12 +113,20 @@ export class SfuSession {
   // Shared PartyTracks config reused for each per-session subTracks instance.
   private readonly subTracksConfig: ConstructorParameters<typeof PartyTracks>[0]
 
+  // Single live Headers instance shared by the publish and every subscribe
+  // PartyTracks. partytracks reads config.headers on EVERY request, so
+  // updating this object (on token refresh/re-login) means all SFU requests —
+  // including partytracks' internal retries — carry the current token. A
+  // header snapshotted at construction goes stale after the 15-minute access
+  // TTL and turns every later SFU request into a permanent 401.
+  private readonly authHeaders = new Headers()
+  private readonly unsubscribeTokenChange: () => void
+
   constructor(opts: SfuSessionOptions) {
     this.opts = opts
 
-    const headers = new Headers()
-    const auth = apiBearerHeaders().Authorization
-    if (auth) headers.set('Authorization', auth)
+    this.syncAuthHeader()
+    this.unsubscribeTokenChange = subscribeTokenChange(() => this.syncAuthHeader())
 
     const baseParams = `roomId=${encodeURIComponent(opts.roomId)}&peerId=${encodeURIComponent(opts.peerId)}`
 
@@ -125,7 +134,7 @@ export class SfuSession {
       prefix: `${httpServerUri}/sfu`,
       apiExtraParams: `${baseParams}&kind=publish`,
       iceServers: opts.iceServers,
-      headers,
+      headers: this.authHeaders,
     })
 
     // Shared config used when creating per-session subscribe PartyTracks.
@@ -135,7 +144,7 @@ export class SfuSession {
       prefix: `${httpServerUri}/sfu`,
       apiExtraParams: `${baseParams}&kind=subscribe`,
       iceServers: opts.iceServers,
-      headers,
+      headers: this.authHeaders,
     }
 
     // pubConnStateSub is wired lazily in publishTrack() — see field comment.
@@ -143,6 +152,12 @@ export class SfuSession {
     // Per-session subTracks instances are created lazily in subscribeTrack().
     // This keeps subscribe-side CF sessions from being allocated until there
     // is actually a remote peer to subscribe to.
+  }
+
+  private syncAuthHeader(): void {
+    const auth = apiBearerHeaders().Authorization
+    if (auth) this.authHeaders.set('Authorization', auth)
+    else this.authHeaders.delete('Authorization')
   }
 
   // Pushes every track in the stream. Idempotent per kind — calling with a
@@ -359,6 +374,7 @@ export class SfuSession {
     for (const t of this.pullTimers.values()) clearTimeout(t)
     for (const t of this.pushAckTimers.values()) clearTimeout(t)
     this.pubConnStateSub?.unsubscribe()
+    this.unsubscribeTokenChange()
     this.localSubjects.clear()
     this.localPushSubs.clear()
     this.publishedMeta.clear()


### PR DESCRIPTION
## Incident

2026-06-11, room `5uq-8haq-ptr` (Sentry issue 121692468, `failure_reason: no_tracks_announced`): a user with an expired access token and a dead refresh cookie joined a call normally — signaling and `/ice-servers` don't validate the token — then **every** partytracks request (`POST /sfu/sessions/new`) returned 401 in an infinite retry loop (50+ in the server logs). They could neither publish nor receive media, with no UI signal, and a reload didn't help.

Root cause behind the dead refresh: the refresh cookie is `SameSite=Strict` while the frontend (getsessionly.com) and API (api.vartalaap.vaishnavghenge.com) are **cross-site**, so the cookie is never sent from production pages. That needs the API moved under `api.getsessionly.com` (separate infra change). This PR fixes the layers that turned an auth hiccup into a silent dead call — and that are needed regardless, since the 15-minute access TTL guarantees mid-call expiry.

## Changes

- **Live SFU auth headers**: `SfuSession` now shares one mutable `Headers` object across the publish and all subscribe PartyTracks instances, updated via a new token-change subscription (`subscribeTokenChange` in `token.ts`). partytracks reads `config.headers` per request, so its internal retries automatically pick up a refreshed token — no more header frozen at construction.
- **In-call session keepalive** (`session-keepalive.ts`): decodes the JWT `exp` and refreshes ~60s before expiry while a call is active. Auth becomes invisible for calls of any length. Guests (room token only) are a no-op.
- **Lobby preflight**: clicking Join first validates the session via `getMe()` (which transparently refreshes). Only a confirmed-dead session (failed refresh, token cleared) blocks — the user then chooses **Sign in again** (returns to the room via `?next=`, internal-paths-only) or **Continue as a guest** (knock/admit). Transient server errors never block joining.
- **Mid-call session death**: the call keeps running (media/signaling don't need the token); a persistent toast with a Sign in action explains what stopped working, plus a Sentry event.
- `/login` honors a sanitized `?next=` return path.

## Tests

198/198 pass. New coverage: keepalive scheduling/renewal loop, single-fire `onSessionDead`, guest no-op, stop(); SfuSession live-header update on token change/sign-out and shared Headers across pub+sub instances. `tsc --noEmit` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)